### PR TITLE
fix: open file in binary mode

### DIFF
--- a/zap_report_formatter/zap_report_formatter.py
+++ b/zap_report_formatter/zap_report_formatter.py
@@ -70,7 +70,7 @@ def write_to_file(xml, filename):
     f = BytesIO()
     et = ET.ElementTree(xml)
     et.write(f, encoding='utf-8', xml_declaration=True)
-    outfile = open(filename, 'w')
+    outfile = open(filename, 'wb')
     outfile.write(f.getvalue())
     outfile.close
 


### PR DESCRIPTION
outfile expected a string but got a binary data in parameter -> now it expects binary data to write into the file